### PR TITLE
Refactor firmware into modular services and switch to ArduinoJson

### DIFF
--- a/include/App.h
+++ b/include/App.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <Arduino.h>
+
+#include "AppConfig.h"
+#include "HttpService.h"
+#include "LedRenderer.h"
+#include "MapParser.h"
+#include "WifiService.h"
+
+class App {
+ public:
+  void begin();
+  void loop();
+
+ private:
+  WifiService wifiService_;
+  HttpService httpService_;
+  MapParser mapParser_;
+  LedRenderer ledRenderer_;
+
+  unsigned long lastFetchMs_ = 0;
+  int temperatureValues_[AppConfig::LED_COUNT] = {0};
+};

--- a/include/AppConfig.h
+++ b/include/AppConfig.h
@@ -1,0 +1,21 @@
+#pragma once
+
+namespace AppConfig {
+
+constexpr const char* WIFI_SSID = "";
+constexpr const char* WIFI_PASSWORD = "";
+constexpr const char* JSON_URL = "http://tmep.cz/vystup-json.php?okresy_cr=1";
+
+constexpr int LED_COUNT = 77;
+constexpr int LED_PIN = 27;
+constexpr int LED_CHANNEL = 0;
+constexpr int LED_BRIGHTNESS = 10;
+
+constexpr unsigned long FETCH_INTERVAL_MS = 1000;
+
+constexpr int TEMP_MIN = -15;
+constexpr int TEMP_MAX = 40;
+constexpr int WHEEL_MIN = 170;
+constexpr int WHEEL_MAX = 0;
+
+}  // namespace AppConfig

--- a/include/HttpService.h
+++ b/include/HttpService.h
@@ -1,0 +1,8 @@
+#pragma once
+
+#include <Arduino.h>
+
+class HttpService {
+ public:
+  bool get(const char* url, String& payload);
+};

--- a/include/LedRenderer.h
+++ b/include/LedRenderer.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <Arduino.h>
+
+class LedRenderer {
+ public:
+  void begin();
+  void renderTemperatures(const int* values, size_t count);
+};

--- a/include/MapParser.h
+++ b/include/MapParser.h
@@ -1,0 +1,8 @@
+#pragma once
+
+#include <Arduino.h>
+
+class MapParser {
+ public:
+  bool parse(const String& payload, int* outValues, size_t outCount);
+};

--- a/include/WifiService.h
+++ b/include/WifiService.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <Arduino.h>
+
+class WifiService {
+ public:
+  void begin();
+  bool isConnected() const;
+  String localIp() const;
+};

--- a/platformio.ini
+++ b/platformio.ini
@@ -3,5 +3,5 @@ platform = espressif32
 board = esp32dev
 framework = arduino
 lib_deps =
-    arduino-libraries/Arduino_JSON
+    bblanchon/ArduinoJson
     https://github.com/Freenove/Freenove_WS2812_Lib_for_ESP32

--- a/src/App.cpp
+++ b/src/App.cpp
@@ -1,0 +1,38 @@
+#include "App.h"
+
+#include "AppConfig.h"
+
+void App::begin() {
+  Serial.begin(115200);
+  delay(10);
+  Serial.println();
+  Serial.println();
+
+  wifiService_.begin();
+  ledRenderer_.begin();
+}
+
+void App::loop() {
+  const unsigned long now = millis();
+  if ((now - lastFetchMs_) < AppConfig::FETCH_INTERVAL_MS) {
+    return;
+  }
+
+  lastFetchMs_ = now;
+
+  if (!wifiService_.isConnected()) {
+    Serial.println("WiFi Disconnected");
+    return;
+  }
+
+  String payload;
+  if (!httpService_.get(AppConfig::JSON_URL, payload)) {
+    return;
+  }
+
+  if (!mapParser_.parse(payload, temperatureValues_, AppConfig::LED_COUNT)) {
+    return;
+  }
+
+  ledRenderer_.renderTemperatures(temperatureValues_, AppConfig::LED_COUNT);
+}

--- a/src/HttpService.cpp
+++ b/src/HttpService.cpp
@@ -1,0 +1,25 @@
+#include "HttpService.h"
+
+#include <HTTPClient.h>
+#include <WiFi.h>
+
+bool HttpService::get(const char* url, String& payload) {
+  WiFiClient client;
+  HTTPClient http;
+
+  http.begin(client, url);
+  const int httpResponseCode = http.GET();
+
+  if (httpResponseCode > 0) {
+    Serial.print("HTTP Response code: ");
+    Serial.println(httpResponseCode);
+    payload = http.getString();
+    http.end();
+    return true;
+  }
+
+  Serial.print("HTTP GET failed, code: ");
+  Serial.println(httpResponseCode);
+  http.end();
+  return false;
+}

--- a/src/LedRenderer.cpp
+++ b/src/LedRenderer.cpp
@@ -1,0 +1,38 @@
+#include "LedRenderer.h"
+
+#include "AppConfig.h"
+#include "Freenove_WS2812_Lib_for_ESP32.h"
+
+namespace {
+Freenove_ESP32_WS2812 strip(
+    AppConfig::LED_COUNT,
+    AppConfig::LED_PIN,
+    AppConfig::LED_CHANNEL,
+    TYPE_GRB);
+}
+
+void LedRenderer::begin() {
+  strip.begin();
+  strip.setBrightness(AppConfig::LED_BRIGHTNESS);
+}
+
+void LedRenderer::renderTemperatures(const int* values, size_t count) {
+  const size_t ledCount = count < static_cast<size_t>(AppConfig::LED_COUNT)
+                              ? count
+                              : static_cast<size_t>(AppConfig::LED_COUNT);
+
+  for (size_t i = 0; i < ledCount; ++i) {
+    const int wheelValue = map(
+        values[i],
+        AppConfig::TEMP_MIN,
+        AppConfig::TEMP_MAX,
+        AppConfig::WHEEL_MIN,
+        AppConfig::WHEEL_MAX);
+
+    Serial.print(wheelValue);
+    strip.setLedColorData(i, strip.Wheel(wheelValue));
+  }
+
+  strip.show();
+  Serial.println();
+}

--- a/src/MapParser.cpp
+++ b/src/MapParser.cpp
@@ -1,0 +1,39 @@
+#include "MapParser.h"
+
+#include <ArduinoJson.h>
+
+bool MapParser::parse(const String& payload, int* outValues, size_t outCount) {
+  // Pole 77 objektů s jednou numerickou hodnotou "h1" + rezerva.
+  // Cíleno na současný payload, aby zůstal memory footprint rozumný.
+  StaticJsonDocument<4096> doc;
+  const DeserializationError error = deserializeJson(doc, payload);
+
+  if (error) {
+    Serial.print("JSON parse failed: ");
+    Serial.println(error.c_str());
+    return false;
+  }
+
+  if (!doc.is<JsonArray>()) {
+    Serial.println("JSON parse failed: root is not array");
+    return false;
+  }
+
+  JsonArray arr = doc.as<JsonArray>();
+  if (arr.size() < outCount) {
+    Serial.println("JSON parse failed: array too short");
+    return false;
+  }
+
+  for (size_t i = 0; i < outCount; ++i) {
+    JsonVariant h1 = arr[i]["h1"];
+    if (h1.isNull()) {
+      Serial.print("JSON parse failed: missing h1 at index ");
+      Serial.println(i);
+      return false;
+    }
+    outValues[i] = h1.as<int>();
+  }
+
+  return true;
+}

--- a/src/WifiService.cpp
+++ b/src/WifiService.cpp
@@ -1,0 +1,30 @@
+#include "WifiService.h"
+
+#include <WiFi.h>
+
+#include "AppConfig.h"
+
+void WifiService::begin() {
+  Serial.print("Connecting to ");
+  Serial.println(AppConfig::WIFI_SSID);
+
+  WiFi.begin(AppConfig::WIFI_SSID, AppConfig::WIFI_PASSWORD);
+
+  while (WiFi.status() != WL_CONNECTED) {
+    delay(500);
+    Serial.print(".");
+  }
+
+  Serial.println();
+  Serial.println("WiFi connected");
+  Serial.print("IP address: ");
+  Serial.println(localIp());
+}
+
+bool WifiService::isConnected() const {
+  return WiFi.status() == WL_CONNECTED;
+}
+
+String WifiService::localIp() const {
+  return WiFi.localIP().toString();
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,87 +1,13 @@
 #include <Arduino.h>
-#include <WiFi.h>
-#include <HTTPClient.h>
-#include <Arduino_JSON.h>
-#include "Freenove_WS2812_Lib_for_ESP32.h"
 
-#define LEDS_COUNT  77
-#define LEDS_PIN    27
-#define CHANNEL     0
+#include "App.h"
 
-const char* ssid       = "";
-const char* password   = "";
-const char* serverName = "http://tmep.cz/vystup-json.php?okresy_cr=1";
+App app;
 
-unsigned long lastTime  = 0;
-unsigned long timerDelay = 1000;
-int color;
-
-Freenove_ESP32_WS2812 strip = Freenove_ESP32_WS2812(LEDS_COUNT, LEDS_PIN, CHANNEL, TYPE_GRB);
-
-String sensorReadings;
-
-String httpGETRequest(const char* serverName);
-
-void setup()
-{
-    Serial.begin(115200);
-    delay(10);
-    Serial.println();
-    Serial.println();
-    Serial.print("Connecting to ");
-    Serial.println(ssid);
-    WiFi.begin(ssid, password);
-    while (WiFi.status() != WL_CONNECTED) {
-        delay(500);
-        Serial.print(".");
-    }
-    Serial.println("");
-    Serial.println("WiFi connected");
-    Serial.println("IP address: ");
-    Serial.println(WiFi.localIP());
-    strip.begin();
-    strip.setBrightness(10);
+void setup() {
+  app.begin();
 }
 
-void loop()
-{
-    if ((millis() - lastTime) > timerDelay) {
-        if (WiFi.status() == WL_CONNECTED) {
-            sensorReadings = httpGETRequest(serverName);
-            JSONVar myObject = JSON.parse(sensorReadings);
-            if (JSON.typeof(myObject) == "undefined") {
-                Serial.println("Parsing input failed!");
-                return;
-            }
-            for (int i = 0; i < 77; i++) {
-                color = map(myObject[i]["h1"], -15, 40, 170, 0);
-                Serial.print(color);
-                strip.setLedColorData(i, strip.Wheel(color));
-            }
-            strip.show();
-            Serial.println();
-        } else {
-            Serial.println("WiFi Disconnected");
-        }
-        lastTime = millis();
-    }
-}
-
-String httpGETRequest(const char* serverName)
-{
-    WiFiClient client;
-    HTTPClient http;
-    http.begin(client, serverName);
-    int httpResponseCode = http.GET();
-    String payload = "{}";
-    if (httpResponseCode > 0) {
-        Serial.print("HTTP Response code: ");
-        Serial.println(httpResponseCode);
-        payload = http.getString();
-    } else {
-        Serial.print("Error code: ");
-        Serial.println(httpResponseCode);
-    }
-    http.end();
-    return payload;
+void loop() {
+  app.loop();
 }


### PR DESCRIPTION
### Motivation
- Rozdělit monolitický firmware do jednoduchých modulů pro lepší udržitelnost a připravenost na další rozšíření. 
- Centralizovat konfiguraci a odstranit magické konstanty z business logiky přes `AppConfig`. 
- Zachovat stávající chování (Wi‑Fi connect, periodický HTTP fetch, čtení `h1`, mapování přes `Wheel()` a vykreslení 77 LED) a bezpečně přejít z `Arduino_JSON` na `ArduinoJson`.

### Description
- Přidány moduly a soubory: `include/AppConfig.h`, `include/App.h`/`src/App.cpp`, `include/WifiService.h`/`src/WifiService.cpp`, `include/HttpService.h`/`src/HttpService.cpp`, `include/MapParser.h`/`src/MapParser.cpp`, `include/LedRenderer.h`/`src/LedRenderer.cpp`, a `src/main.cpp` převeden na minimální bootstrap. 
- `AppConfig` centralizuje nastavení včetně `WIFI_SSID`, `WIFI_PASSWORD`, `JSON_URL`, `LED_COUNT`, `LED_PIN`, `LED_CHANNEL`, `LED_BRIGHTNESS`, `FETCH_INTERVAL_MS`, `TEMP_MIN`, `TEMP_MAX`, `WHEEL_MIN` a `WHEEL_MAX`. 
- `WifiService` implementuje `void begin()`, `bool isConnected() const` a `String localIp() const` a drží původní blokující inicializaci Wi‑Fi (nezměněná logika připojení). 
- `HttpService::get(const char* url, String& payload)` vrací `true/false` a payload přes výstupní parametr a loguje HTTP response code; `MapParser::parse` používá `ArduinoJson` s `StaticJsonDocument<4096>` (konzervativní velikost navržena pro ~77 objektů a jednu hodnotu `h1`). 
- `LedRenderer` inicializuje `Freenove_ESP32_WS2812`, provádí mapování hodnot (`map(value, TEMP_MIN, TEMP_MAX, WHEEL_MIN, WHEEL_MAX)`) a vykresluje LED; `App` orchestruje periodický fetch/parse/render bez `delay()` v `loop()`. 
- Aktualizováno `platformio.ini` pro přechod z `arduino-libraries/Arduino_JSON` na `bblanchon/ArduinoJson` a zachování Freenove WS2812 knihovny.

### Testing
- Pokus o sestavení přes `pio run` selhal, protože v prostředí není nainstalovaný příkaz `pio`. 
- Pokus o sestavení přes `python -m platformio run` selhal, protože v prostředí není dostupný Python modul `platformio`, takže kompilace nemohla být ověřena automaticky.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b84f23a9788322bc0280168e234bdf)