### PR TITLE
Add `ledOrder` config and LaskaKit ID remapping for OBJECT_LIST_ID_RGB

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ Konfigurace se ukládá jako `/config.json` v LittleFS. Po prvním nahrání lze
 | `brightness` | Jas LED diod (0–255, výchozí: `10`) |
 | `wheelMin` | Počáteční pozice na barevném kole pro `minValue` (výchozí: `170` = modrá) |
 | `wheelMax` | Koncová pozice na barevném kole pro `maxValue` (výchozí: `0` = červená) |
+| `ledOrder` | Formát vstupních `id` v parseru `OBJECT_LIST_ID_RGB`: `TVOJEMAMA` (= nativní TMEP ID) nebo `LASKAKIT` (= LaskaKit ID) |
 
 ---
 
@@ -235,7 +236,7 @@ Pojmenované pole, barva LED se čte přímo z `colorField` ve formátu hex (`#R
 
 ### `OBJECT_LIST_ID_RGB`
 
-Root JSON je objekt. Parser očekává pole `seznam`, kde každá položka obsahuje `id` (index LED) a přímé RGB složky `r`, `g`, `b`. Pole `utc_datum` (a jakákoliv další metadata) jsou tolerována a ignorována.
+Root JSON je objekt. Parser očekává pole `seznam`, kde každá položka obsahuje `id` a přímé RGB složky `r`, `g`, `b`. Pole `utc_datum` (a jakákoliv další metadata) jsou tolerována a ignorována. Význam `id` určuje `render.ledOrder`: `TVOJEMAMA` = nativní TMEP ID, `LASKAKIT` = LaskaKit ID přemapované interně na nativní pořadí LED.
 
 ```json
 {

--- a/data/index.html
+++ b/data/index.html
@@ -55,10 +55,10 @@
         <label>Brightness <input name="brightness" type="number" min="0" max="255" /></label>
         <label>Wheel min <input name="wheelMin" type="number" /></label>
         <label>Wheel max <input name="wheelMax" type="number" /></label>
-        <label>LED pořadí (HW varianta)
+        <label>Input order (ID v JSON)
           <select name="ledOrder">
-            <option value="TVOJEMAMA">TvojeMama (nativní)</option>
-            <option value="LASKAKIT">LaskaKit</option>
+            <option value="TVOJEMAMA">TvojeMama / TMEP ID</option>
+            <option value="LASKAKIT">LaskaKit ID</option>
           </select>
         </label>
         <div class="buttons">

--- a/include/DataParser.h
+++ b/include/DataParser.h
@@ -59,6 +59,7 @@ class DataParser {
       ParseStats* outStats);
   bool parseObjectListIdRgb(
       JsonObjectConst rootObject,
+      const String& inputOrder,
       LedState* outStates,
       size_t count,
       ParseStats* outStats) const;

--- a/src/DataParser.cpp
+++ b/src/DataParser.cpp
@@ -6,6 +6,33 @@ namespace {
 uint8_t parseHexByte(const String& value) {
   return static_cast<uint8_t>(strtoul(value.c_str(), nullptr, 16));
 }
+
+// Mapování TMEP ID (1..77) -> LaskaKit ID (1..72, neosazené pozice jsou -1).
+constexpr int kTmepToLaskaKit[AppDefaults::LED_COUNT] = {
+    25, 20, 17, 11, 16, 10, 7, 9, 4, 1, 5, 2, 3, 6, 12, 8, 13, 19, 22, 30, 28, 35, 39, 32, 18, 26,
+    46, 31, 37, 36, 43, 45, 57, 49, 62, 58, 66, 69, 60, 50, 56, 64, -1, 72, 70, 63, 48, 54, 47, 52,
+    65, 53, 68, 71, 67, 61, 59, 55, 51, 38, -1, 41, -1, 42, 24, 23, 15, 14, 21, 29, 34, 40, 44, 33,
+    -1, -1, 27,
+};
+
+int logicalIndexFromInputId(int inputId, const String& inputOrder) {
+  if (inputId < 1 || inputId > AppDefaults::LED_COUNT) {
+    return -1;
+  }
+
+  if (inputOrder != "LASKAKIT") {
+    return inputId - 1;
+  }
+
+  for (size_t tmepIndex = 0; tmepIndex < AppDefaults::LED_COUNT; ++tmepIndex) {
+    if (kTmepToLaskaKit[tmepIndex] == inputId) {
+      return static_cast<int>(tmepIndex);
+    }
+  }
+
+  // LaskaKit ID existuje v datech, ale na nativní desce mu neodpovídá žádná LED.
+  return -1;
+}
 }  // namespace
 
 bool DataParser::parse(
@@ -88,7 +115,12 @@ bool DataParser::parse(
       }
 
       JsonObjectConst rootObject = doc.as<JsonObjectConst>();
-      return parseObjectListIdRgb(rootObject, outStates, count, outStats);
+      return parseObjectListIdRgb(
+          rootObject,
+          config.render.ledOrder,
+          outStates,
+          count,
+          outStats);
     }
     default:
       Serial.println("DataParser: unsupported parser type");
@@ -296,6 +328,7 @@ bool DataParser::parseNamedColorField(
 
 bool DataParser::parseObjectListIdRgb(
     JsonObjectConst rootObject,
+    const String& inputOrder,
     LedState* outStates,
     size_t count,
     ParseStats* outStats) const {
@@ -326,7 +359,7 @@ bool DataParser::parseObjectListIdRgb(
       continue;
     }
 
-    const int ledIndex = id.as<int>() - 1;
+    const int ledIndex = logicalIndexFromInputId(id.as<int>(), inputOrder);
     if (ledIndex < 0 || static_cast<size_t>(ledIndex) >= count) {
       ++unknownCount;
       lastItemError = "OBJECT_LIST_ID_RGB id out of range";

--- a/src/LedRenderer.cpp
+++ b/src/LedRenderer.cpp
@@ -5,15 +5,6 @@
 namespace {
 CRGB leds[AppDefaults::LED_COUNT];
 
-// Mapování TMEP okresů (index 0..76 => TMEP ID 1..77) na fyzické LED pořadí
-// LaskaKit. Hodnota -1 znamená, že pro daný okres není LED k dispozici.
-constexpr int kLaskaKitOrder[AppDefaults::LED_COUNT] = {
-    24, 19, 16, 10, 15, 9, 6, 8, 3, 0, 4, 1, 2, 5, 11, 7, 12, 18, 21, 29, 27, 34, 38, 31, 17, 25,
-    45, 30, 36, 35, 42, 44, 56, 48, 61, 57, 65, 68, 59, 49, 55, 63, -1, 71, 69, 62, 47, 53, 46, 51,
-    64, 52, 67, 70, 66, 60, 58, 54, 50, 37, -1, 40, -1, 41, 23, 22, 14, 13, 20, 28, 33, 39, 43, 32,
-    -1, -1, 26,
-};
-
 float clampf(float value, float minValue, float maxValue) {
   if (value < minValue) return minValue;
   if (value > maxValue) return maxValue;
@@ -123,11 +114,6 @@ int LedRenderer::mapLogicalToPhysicalIndex(size_t logicalIndex) const {
   if (logicalIndex >= static_cast<size_t>(AppDefaults::LED_COUNT)) {
     return -1;
   }
-
-  if (renderConfig_.ledOrder == "LASKAKIT") {
-    return kLaskaKitOrder[logicalIndex];
-  }
-
   return static_cast<int>(logicalIndex);
 }
 


### PR DESCRIPTION
### Motivation

- Allow the `OBJECT_LIST_ID_RGB` parser to accept different ID formats by introducing an input-order option and remapping LaskaKit IDs to the native LED ordering. 
- Move ID remapping out of the renderer into the parser so the renderer always receives logical LED indices and only needs to map logical->physical.

### Description

- Documented new `render.ledOrder` option in `README.md` and updated `OBJECT_LIST_ID_RGB` docs to describe how `id` is interpreted and remapped. 
- Added `ledOrder` form field and clearer option labels in `data/index.html` for the web configuration UI. 
- Extended `DataParser` API: `parseObjectListIdRgb` now accepts an `inputOrder` parameter and the `parse` path passes `config.render.ledOrder` to the parser. 
- Implemented `kTmepToLaskaKit` mapping and `logicalIndexFromInputId` helper in `DataParser.cpp` to remap `LASKAKIT` IDs to native logical indices, and updated `parseObjectListIdRgb` to use this remapping. 
- Removed the previous LaskaKit mapping from `LedRenderer` so the renderer always assumes logical indexing and only performs logical->physical mapping.

### Testing

- Built the firmware (`PlatformIO` / project build) after the changes and the build completed successfully. 
- No automated unit tests were present for the changed parsing/rendering logic, so only compilation was verified.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd29eedd9c8322b3ffc2f40d785c96)